### PR TITLE
Add deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # Plataforma de Propostas Comerciais - Sagacy v2.0
 
 ✅ **Projeto concluído com sucesso em 09/07/2025**
@@ -11,15 +10,13 @@
 - **Testes**: `teste-api.html` (validado)
 
 ## 🚀 **Como usar:**
-
 1. **Abra** `index.html` no navegador
 2. **Teste** todas as funcionalidades
 3. **Personalize** dados da empresa se necessário
 4. **Use** em produção
 
 ## 📁 **Estrutura Final:**
-
-```
+``` 
 📁 nova-plataforma-sagacy-v2/
 ├── 📄 index.html                    # ✅ Aplicação principal
 ├── 📄 teste-api.html               # ✅ Testes da API
@@ -31,7 +28,6 @@
 ```
 
 ## 🏆 **Conquistas:**
-
 - ✅ **Modularização completa** (index.html gigante quebrado)
 - ✅ **Backend Google Apps Script** integrado
 - ✅ **API REST funcional** com 5 endpoints
@@ -40,13 +36,16 @@
 - ✅ **Documentação completa** para manutenção
 
 ## 🔧 **Personalização:**
-
 ### **Próximo passo:** Atualizar dados da empresa
 - Nomes dos colaboradores
 - Produtos/serviços reais
 - Informações de contato
 
+### Paleta de cores
+A paleta padrão continua definida em `css/style.css`. Edite as variáveis `--primary`, `--accent` e demais cores no início desse arquivo para personalizar.
+
+### Publicação gratuita
+Consulte `docs/deploy.md` para um passo a passo de como hospedar a plataforma no **GitHub Pages** sem custos.
+
 **🎯 Plataforma pronta para personalização e uso!**
-=======
-# propostas
->>>>>>> be7cea921156b1572ec1ef3e303eb3a6f20bd715
+

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,31 @@
+# 📦 Guia de Publicação Gratuita
+
+Este documento explica como publicar a plataforma **Sagacy** gratuitamente utilizando **GitHub Pages**.
+
+## 1. Criar um repositório
+1. Acesse [github.com](https://github.com) e crie uma conta se ainda não tiver.
+2. Crie um novo repositório (público).
+
+## 2. Enviar os arquivos do projeto
+1. No seu computador, abra o terminal na pasta do projeto.
+2. Inicialize o repositório e envie os arquivos:
+   ```bash
+   git init
+   git add .
+   git commit -m "Publicação inicial"
+   git branch -M main
+   git remote add origin https://github.com/<seu-usuario>/<seu-repo>.git
+   git push -u origin main
+   ```
+
+## 3. Ativar o GitHub Pages
+1. Dentro do repositório no GitHub, abra **Settings**.
+2. Na seção **Pages**, escolha a branch `main` e a pasta `/` (root).
+3. Salve. Em alguns instantes a URL será disponibilizada.
+
+A página ficará acessível em `https://<seu-usuario>.github.io/<seu-repo>/`.
+
+## 4. Acessar o sistema
+Basta abrir a URL gerada e acessar `index.html`. Todo o front-end será carregado diretamente pelo GitHub Pages.
+
+Assim você publica a plataforma sem custos e com atualização simples sempre que fizer novos commits.


### PR DESCRIPTION
## Summary
- add instructions on publishing via GitHub Pages
- mention color palette location and the new deployment guide in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870251eba688320a5b582a634075e71