### PR TITLE
Add free hosting guide

### DIFF
--- a/docs/DEPLOY-GRATUITO.md
+++ b/docs/DEPLOY-GRATUITO.md
@@ -1,0 +1,22 @@
+# 🌐 Publicação Gratuita da Plataforma
+
+Este guia rápido ensina a publicar os arquivos estáticos do projeto (HTML, CSS e JS) em serviços gratuitos. O backend em Google Apps Script permanece o mesmo.
+
+## 🚀 Opção 1: GitHub Pages
+
+1. Crie uma conta em [github.com](https://github.com) se ainda não tiver.
+2. No GitHub, clique em **New repository** e envie todos os arquivos deste projeto.
+3. Acesse **Settings** → **Pages**.
+4. Em **Source**, escolha a branch `main` e a pasta `/` (root).
+5. Clique em **Save** e aguarde a URL ser gerada (ex.: `https://seu-usuario.github.io/seu-repositorio/`).
+6. Abra a URL no navegador e verifique o funcionamento do `index.html`.
+
+## 🚀 Opção 2: Vercel
+
+1. Crie uma conta em [vercel.com](https://vercel.com).
+2. Escolha **Import Git Repository** e conecte ao repositório do GitHub.
+3. Clique em **Deploy** para gerar a URL gratuita (ex.: `https://seu-projeto.vercel.app`).
+
+## ℹ️ Observação sobre a API
+
+O backend continua hospedado no **Google Apps Script**. Caso você altere a URL da API, lembre-se de atualizar o valor correspondente no código JavaScript do projeto.


### PR DESCRIPTION
## Summary
- add `docs/DEPLOY-GRATUITO.md` with instructions to deploy the frontend on GitHub Pages or Vercel

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68702538b47c83208da4a6aa2f73de21